### PR TITLE
Syntax highlighting for AspectJ

### DIFF
--- a/conf/docbook-config/xslthl-config.xml
+++ b/conf/docbook-config/xslthl-config.xml
@@ -29,6 +29,7 @@ Customized for the Asciidoctor project (http://asciidoctor.org).
 Several of the lesser used languages have been removed.
 -->
 <xslthl-config>
+	<highlighter id="aspectj" file="./xslthl/aspectj-hl.xml"/>
     <highlighter id="java" file="./xslthl/java-hl.xml"/>
     <highlighter id="groovy" file="./xslthl/java-hl.xml"/>
     <highlighter id="html" file="./xslthl/html-hl.xml"/>

--- a/conf/docbook-config/xslthl/aspectj-hl.xml
+++ b/conf/docbook-config/xslthl/aspectj-hl.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Syntax highlighting definition for AspectJ
+
+-->
+<highlighters>
+	<highlighter type="multiline-comment">
+		<start>/**</start>
+		<end>*/</end>
+		<style>doccomment</style>
+	</highlighter>
+	<highlighter type="multiline-comment">
+		<start>/*</start>
+		<end>*/</end>
+	</highlighter>
+	<highlighter type="oneline-comment">//</highlighter>
+	<highlighter type="string">
+		<string>"</string>
+		<escape>\</escape>
+	</highlighter>
+	<highlighter type="string">
+		<string>'</string>
+		<escape>\</escape>
+	</highlighter>
+	<highlighter type="annotation">
+		<start>@</start>
+		<valueStart>(</valueStart>
+		<valueEnd>)</valueEnd>
+	</highlighter>
+	<highlighter type="hexnumber">
+		<prefix>0x</prefix>
+		<ignoreCase />
+	</highlighter>
+	<highlighter type="number">
+		<point>.</point>
+		<exponent>e</exponent>
+		<suffix>f</suffix>
+		<suffix>d</suffix>
+		<suffix>l</suffix>
+		<ignoreCase />
+	</highlighter>
+	<highlighter type="keywords">
+		<keyword>abstract</keyword>
+		<keyword>boolean</keyword>
+		<keyword>break</keyword>
+		<keyword>byte</keyword>
+		<keyword>case</keyword>
+		<keyword>catch</keyword>
+		<keyword>char</keyword>
+		<keyword>class</keyword>
+		<keyword>const</keyword>
+		<keyword>continue</keyword>
+		<keyword>default</keyword>
+		<keyword>do</keyword>
+		<keyword>double</keyword>
+		<keyword>else</keyword>
+		<keyword>extends</keyword>
+		<keyword>final</keyword>
+		<keyword>finally</keyword>
+		<keyword>float</keyword>
+		<keyword>for</keyword>
+		<keyword>goto</keyword>
+		<keyword>if</keyword>
+		<keyword>implements</keyword>
+		<keyword>import</keyword>
+		<keyword>instanceof</keyword>
+		<keyword>int</keyword>
+		<keyword>interface</keyword>
+		<keyword>long</keyword>
+		<keyword>native</keyword>
+		<keyword>new</keyword>
+		<keyword>package</keyword>
+		<keyword>private</keyword>
+		<keyword>protected</keyword>
+		<keyword>public</keyword>
+		<keyword>return</keyword>
+		<keyword>short</keyword>
+		<keyword>static</keyword> 
+		<keyword>strictfp</keyword>
+		<keyword>super</keyword>
+		<keyword>switch</keyword>
+		<keyword>synchronized</keyword>
+		<keyword>this</keyword>
+		<keyword>throw</keyword>
+		<keyword>throws</keyword>
+		<keyword>transient</keyword>
+		<keyword>try</keyword>
+		<keyword>void</keyword>
+		<keyword>volatile</keyword>
+		<keyword>while</keyword>		
+		<keyword>pointcut</keyword>
+		<keyword>aspect</keyword>
+		<keyword>after</keyword>
+		<keyword>before</keyword>
+		<keyword>returning</keyword>
+		<keyword>throwing</keyword>
+		<keyword>around</keyword>
+		<keyword>call</keyword>
+		<keyword>execution</keyword>
+		<keyword>proceed</keyword>
+		<keyword>target</keyword>
+		<keyword>withincode</keyword>
+		<keyword>privileged</keyword>
+		<keyword>args</keyword>
+		<keyword>issingleton</keyword>
+		<keyword>within</keyword>
+		<keyword>precedence</keyword>
+		<keyword>declare</keyword>
+		<keyword>cflow</keyword>
+		<keyword>get</keyword>
+		<keyword>set</keyword>
+		<keyword>handler</keyword>
+		<keyword>initialization</keyword>
+		<keyword>preinitialization</keyword>
+		<keyword>adviceexecution</keyword>
+		<keyword>cflowbelow</keyword>
+		<keyword>staticinitialization</keyword>
+		<keyword>perthis</keyword>
+		<keyword>pertarget</keyword>
+		<keyword>percflow</keyword>
+		<keyword>percflowbelow</keyword>
+		<keyword>pertypewithin</keyword>
+	</highlighter>
+</highlighters>


### PR DESCRIPTION
AsciidocFX can now support syntax highlighting for the AspectJ language based on PDF Book.
Here is an example about how to do so:

   [source,aspectj]

   public aspect AspectModule {
         // aspect definition
  }
