### PR TITLE
Manipulate the behavior of the selected text

### DIFF
--- a/src/main/resources/public/js/editor-shortcuts.js
+++ b/src/main/resources/public/js/editor-shortcuts.js
@@ -246,14 +246,14 @@ editor.commands.addCommand({
     readOnly: true
 });
 
-var matchBoldText = function(text){
+function matchBoldText(text){
     return text.match(/\*.*\*/g) != null;
 } 
 
-var matchItalicizedText = function(text){
+function matchItalicizedText(text){
     return text.match(/\_.*\_/g) != null;
 }
 
-var matchCode = function(text){
+function matchCode(text){
     return text.match(/\`.*\`/g) != null;
 }


### PR DESCRIPTION
Hi Rahman,

I have just made some modifications about the specific shortcuts manipulating the selected text such as bold, italic and code ('`' '`') selections.

We can change the behavior of the selected text handily using these changes. Here is the gif showing what the PR can do with the selected content:

![keyframe](https://cloud.githubusercontent.com/assets/1964927/5154096/f152a810-7250-11e4-974e-e4e390ae248f.gif)

So as usual, what do you think about it? :)
