### PR TITLE
set options when converting to HTML

### DIFF
--- a/src/main/resources/public/js/index.js
+++ b/src/main/resources/public/js/index.js
@@ -1,8 +1,11 @@
 function convertBasicHtml(content) {
+    var options = Opal.hash2(['backend', 'safe', 'attributes'], {
+      backend: 'html5',
+      safe: 'safe',
+      attributes: 'showtitle icons=font@ source-highlighter=highlight.js platform=opal platform-opal env=browser env-browser'
+    });
 
-    var rendered = Opal.Asciidoctor.$render(content);
-
-    return rendered;
+    return Opal.Asciidoctor.$convert(content, options);
 }
 
 function convertHtmlBook(content) {


### PR DESCRIPTION
- force the backend to html5 (so document cannot override)
- set safe mode to allow font-based icons and other features to be enabled
- show the document title by default
- enable font-based icons by default (but allow document to disable, hence the trailing `@`)
- enable source-highlighter to highlight.js (since it's used automatically)
- set the platform / env attributes to allow for conditional rendering
- update $render method to $convert
