### PR TITLE
Also sort entries of subdirectories.

### DIFF
--- a/src/main/java/com/kodcu/controller/AsciiDocController.java
+++ b/src/main/java/com/kodcu/controller/AsciiDocController.java
@@ -556,14 +556,20 @@ public class AsciiDocController extends TextWebSocketHandler implements Initiali
             if (event.getButton() == MouseButton.PRIMARY)
                 if (Files.isDirectory(selectedPath)) {
                     try {
-                        if (selectedItem.getChildren().size() == 0)
+                        if (selectedItem.getChildren().size() == 0) {
+                            final List<Path> files = new LinkedList<>();
                             Files.newDirectoryStream(selectedPath).forEach(path -> {
                                 if (pathResolver.isHidden(path))
                                     return;
 
                                 if (pathResolver.isViewable(path))
-                                    selectedItem.getChildren().add(new TreeItem<>(new Item(path),awesomeService.getIcon(path)));
+                                    files.add(path);
                             });
+                            Collections.sort(files);
+                            files.forEach(path -> {
+                                selectedItem.getChildren().add(new TreeItem<>(new Item(path),awesomeService.getIcon(path)));
+                            });
+                        }
                         selectedItem.setExpanded(!selectedItem.isExpanded());
                     } catch (IOException e) {
                         e.printStackTrace();


### PR DESCRIPTION
This continues and hopefully completes PR #31. On Linux, files and dir entries are unsorted without this patch.

In #31, I was not aware, that the files for the root level of the tree view are retrieved differently the the ones for sub levels. I suggest, to refactor it to have only one source of files.
