### PR TITLE
Fixed too restrictive file attribute check

### DIFF
--- a/src/main/java/com/kodcu/controller/AsciiDocController.java
+++ b/src/main/java/com/kodcu/controller/AsciiDocController.java
@@ -847,7 +847,7 @@ public class AsciiDocController extends TextWebSocketHandler implements Initiali
 
     public void addTab(Path path) {
 
-        if (!Files.isExecutable(path)) {
+        if (!Files.exists(path)) {
             recentFiles.remove(path.toString());
             return;
         }


### PR DESCRIPTION
No need for executable attribute, which will only work on Windows.

This fixes https://github.com/asciidocfx/AsciidocFX/issues/33.
