### PR TITLE
Added workaround for rainbow text artifacts

### DIFF
--- a/README.asc
+++ b/README.asc
@@ -466,8 +466,17 @@ AFX supports this ace shortcuts https://github.com/ajaxorg/ace/wiki/Default-Keyb
 
 == Known Issues
 
-There is a bug in JavaFX which makes all keyboards on a Mac behave as "QWERTY".
-This means, that on a German "QWERTZ" layout the shortcuts for `undo` and `redo` are swapped.
+Mac QWERTY Keyboard Bug::
+  There is a bug in JavaFX which makes all keyboards on a Mac behave as "QWERTY".
+  This means, that on a German "QWERTZ" layout the shortcuts for `undo` and `redo` are swapped.
+Text Artifacts (Rainbowing) on Text::
+  If you are being distracted by rainbow text artifacts on text, you can work around the issue by passing some VM options in `[Install_Dir]/AsciidocFX.vmoptions`, as shared in https://github.com/TomasMikula/RichTextFX/issues/145[this RichTextFX bug].
+  
+  . Open `AsciidocFX.vmoptions`.
+  . Add `-Dprism.text=t2k` and `-Dprism.lcdtext=false` to the file.
+  . Save and close.
+  . Launch AsciidocFX
+
 
 == Changelog
 


### PR DESCRIPTION
https://github.com/TomasMikula/RichTextFX/issues/145 was the way I fixed some rainbowing of all text in the raw and rendered views for Asciidoc text. Thought I'd note it here so it helps others.