### PR TITLE
Fixed PDF / Save UI option - added missing "file:" prefix to uri's starting with "/".

### DIFF
--- a/src/main/java/com/kodcu/service/convert/pdf/AbstractPdfConverter.java
+++ b/src/main/java/com/kodcu/service/convert/pdf/AbstractPdfConverter.java
@@ -78,6 +78,8 @@ public abstract class AbstractPdfConverter implements DocumentConverter<String> 
                         public Source resolve(String href, String base) throws TransformerException {
                             if (Objects.nonNull(href)) {
                                 try {
+                                    if (href.charAt(0) == '/') href = "file:" + href;
+                                    //logger.debug("href = " + href);
                                     Path path = Paths.get(URI.create(href));
                                     if (!Files.exists(path)) {
 


### PR DESCRIPTION
AsciidoxFX triggers a runtime exception when PDF / Save is selected (using the example book.adoc as reference).

8313 [pool-2-thread-3] ERROR c.k.s.c.pdf.AbstractPdfConverter - Problem occured while converting to PDF 
java.lang.IllegalArgumentException: Missing scheme
        at java.nio.file.Paths.get(Paths.java:134) ~[na:1.8.0_51]
        at com.kodcu.service.convert.pdf.AbstractPdfConverter$1.resolve(AbstractPdfConverter.java:81) ~[AsciidocFX-1.3.7.jar:1.3.7]
        at org.apache.fop.apps.FOUserAgent.resolveURI(FOUserAgent.java:422) [fop-1.1.jar:na]
        at org.apache.fop.apps.FOUserAgent.resolveURI(FOUserAgent.java:402) [fop-1.1.jar:na]
        at org.apache.fop.apps.FOUserAgent$1.resolveURI(FOUserAgent.java:142) [fop-1.1.jar:na]
        at org.apache.xmlgraphics.image.loader.impl.AbstractImageSessionContext.newSource(AbstractImageSessionContext.java:77) [xmlgraphics-commons-1.5.jar:1.5]
        at org.apache.xmlgraphics.image.loader.impl.AbstractImageSessionContext.needSource(AbstractImageSessionContext.java:280) [xmlgraphics-commons-1.5.jar:1.5]
        at org.apache.xmlgraphics.image.loader.cache.ImageCache.needImageInfo(ImageCache.java:123) [xmlgraphics-commons-1.5.jar:1.5]
        at org.apache.xmlgraphics.image.loader.ImageManager.getImageInfo(ImageManager.java:122) [xmlgraphics-commons-1.5.jar:1.5]
        at org.apache.fop.fo.flow.ExternalGraphic.bind(ExternalGraphic.java:81) [fop-1.1.jar:na]
        at org.apache.fop.fo.FObj.processNode(FObj.java:124) [fop-1.1.jar:na]

This fix resolves the "Missing scheme" error encountered. 

Fix tested on Linux Mint 17.2 with Oracle Java 1.8 (u51) (AMD64)
