### PR TITLE
Improve Download Location and Install Heading Visibility

### DIFF
--- a/README.asc
+++ b/README.asc
@@ -31,8 +31,14 @@ image::images/asciidocfx.png[]
 
 == How to Install AsciidocFX
 
-.You can download the latest release from https://github.com/asciidocfx/AsciidocFX/releases[Github releases page].
+There are a number of operating systems that AsciidocFX supports.
 
+NOTE: The latest releases are available from the https://github.com/asciidocfx/AsciidocFX/releases[Github releases page].
+
+<<Supported_OS>> shows the list of available builds with links for reference. If you are looking for the very latest version, visit the link in the note above to be guaranteed of downloading the latest and greatest version of AsciidocFX.
+
+[[Supported_OS]]
+.Supported Operating Systems and Builds 
 [width="100%",options="header"]
 |====================
 | OS | JRE included? | Filename | Size 
@@ -45,7 +51,7 @@ image::images/asciidocfx.png[]
 | No | {download-root}AsciidocFX_Linux_No_JRE.tar.gz[AsciidocFX_Linux_No_JRE.tar.gz] | 32.2 MB
 |====================
 
-*Linux*
+=== Install on Linux
 
 After the download is completed, untar the package in your preferred directory.
 
@@ -53,27 +59,27 @@ After the download is completed, untar the package in your preferred directory.
 $ cd /bin
 $ ./AsciidocFX.sh
 
-*Arch Linux*
+=== Install on Arch Linux
 
-Also you can install with package manager in Arch Linux
+Install using the package manager in Arch Linux
 
 [source,bash]
 $ yaourt -S asciidocfx
 
-*Windows*
+=== Install on Windows
 
 Download executable/installer and run it.
 
-*Mac*
+=== Install on Mac
 
-Download _dmg_ and run it.
+Download the `.dmg` and run it.
 
 === Installation Notes
 
 There are two AsciidocFX package flavors, you can download it with JRE 8 out-of-box or if you have already installed JRE 8 (Update 40 or above), you can download *No_JRE builds
 
 Graphviz::
-PlantUML extension needs Graphviz, if you will use it, then install it:
+  PlantUML extension needs Graphviz, if you will use it, then install it:
 +
 .Ubuntu
 [source,bash]


### PR DESCRIPTION
This fix incorporates the changes suggested in #181. I've also added some extra heading levels so the installation methods for each platform are called out in the TOC.