### PR TITLE
Update brew install command for mac

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -91,7 +91,7 @@ Download the `.dmg` and run it.
 
 or 
 
-Use https://caskroom.github.io/[Homebrew-cask] to install it with one command: `brew cask install asciidocfx`
+Use https://brew.sh/[Homebrew] to install it with one command: `brew install --cask asciidocfx`
 
 
 === Installation Notes


### PR DESCRIPTION
Homebrew Cask was deprecated and is not part of Hombrew. The command is now ´brew install --cask´ instead of ´brew cask install´