### PR TITLE
Remove erroneous path prefix when using absolute paths on windows

### DIFF
--- a/src/main/java/com/kodedu/controller/WebWorkerResource.java
+++ b/src/main/java/com/kodedu/controller/WebWorkerResource.java
@@ -99,6 +99,10 @@ public class WebWorkerResource {
         }
 
         if (optional.isPresent()) {
+            if(finalURI.matches("^file:///[A-Z]:[\\\\/].+$")) {
+                finalURI = finalURI.replace("file:///", "");
+            }
+
             Path found = directoryService.findPathInWorkdirOrLookup(IOHelper.getPath(finalURI));
 
             if (Objects.nonNull(found)) {


### PR DESCRIPTION
Fix #504 , use regex to ensure that the replacement only occurs when receiving erroneous windows paths (checks for drive letter marker)

As discussed in the issue, I believe that this should NOT be merged and should be fixed when parsing asciidoc instead of when requesting a specific file, however I did not figure out where the actual parsing of include directives occurs