### PR TITLE
Add support to set working directory from command-line

### DIFF
--- a/src/main/java/com/kodedu/boot/CmdlineConfig.java
+++ b/src/main/java/com/kodedu/boot/CmdlineConfig.java
@@ -13,4 +13,7 @@ public class CmdlineConfig {
     @CmdOption(args = "FILE", description = "File to open", maxCount = -1)
     final List<String> files = new LinkedList<String>();
 
+    @CmdOption(names = {"--workdir", "-W"}, args = "DIRECTORY", description = "Working directory to use when generating opened files views")
+    String workingDirectory = null;
+
 }


### PR DESCRIPTION
Should be a fix for use-cases such as #199 and a way to give guarantees with the expectation of #460 by allowing to explicitly set the workdir (not a full fix in the second use-case)