### PR TITLE
Add github workflow to automatically test PRs and commits on github

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,63 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Java CI with Maven
+
+env:
+  install4j_download_url: https://download-gcdn.ej-technologies.com/install4j/install4j_linux-x64_9_0_2.tar.gz
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      install4j_download_url:
+        description: Download source for Install4J
+        required: true
+        default: https://download-gcdn.ej-technologies.com/install4j/install4j_linux-x64_9_0_2.tar.gz
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment: install4j
+    strategy:
+      matrix:
+        java: [ 16 ]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v2
+      with:
+        java-version: ${{ matrix.java }}
+        distribution: 'adopt'
+    - name: Build with Maven
+      run: mvn -B -Djava.version=${{ matrix.java }} -Dopenjfx.version=${{ matrix.java }} compile test
+
+      
+  package:
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    strategy:
+      matrix:
+        java: [ 16 ]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v2
+      with:
+        java-version: ${{ matrix.java }}
+        distribution: 'adopt'
+    - name: Download install4j
+      run: |
+         wget --tries=3 ${{ github.event.inputs.install4j_download_url || env.install4j_download_url }} -O install4j.tar.gz
+         mkdir install4j
+         tar -zxvf install4j.tar.gz --strip-components 1 -C install4j
+    - name: Configure Install4J
+      env:
+        LICENSE_KEY_9: ${{ secrets.INSTALL4J_LICENSE_KEY }}
+      run: mvn install4j:install-license
+    - name: Package with maven and install4j
+      run: mvn -B -Dinstall4j.home=install4j -Djava.version=${{ matrix.java }} -Dopenjfx.version=${{ matrix.java }} package


### PR DESCRIPTION
This workflow automatically builds AsciidocFX when a new PR is issued. I added an install4j job but unfortunately could not test it.
I will be adding unit tests when creating future PRs for asciidocfx#519 and thought that having direct feedback on the build's status from within Github without forcing each fork to setup its own CI could prove usefull.