### PR TITLE
Feature/create services interfaces

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,8 @@
         <openjfx.version>16</openjfx.version>
         <ikonli.version>12.2.0</ikonli.version>
         <jaxb.version>2.3.2</jaxb.version>
+        <jacoco.version>0.8.7</jacoco.version>
+        <logunit.version>1.1.0</logunit.version>
     </properties>
 
     <organization>
@@ -242,6 +244,42 @@
             <version>${openjfx.version}</version>
             <scope>provided</scope>
         </dependency>
+        <!-- Add test dependencies -->
+        <dependency>
+            <groupId>io.github.netmikey.logunit</groupId>
+            <artifactId>logunit-core</artifactId>
+            <version>${logunit.version}</version>
+            <scope>test</scope>
+         </dependency>
+        <dependency>
+            <groupId>io.github.netmikey.logunit</groupId>
+            <artifactId>logunit-logback</artifactId>
+            <version>${logunit.version}</version>
+            <scope>test</scope>
+         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+           <groupId>org.springframework.boot</groupId>
+           <artifactId>spring-boot-starter-test</artifactId>
+           <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testfx</groupId>
+            <artifactId>testfx-junit5</artifactId>
+            <version>4.0.16-alpha</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 
@@ -430,9 +468,42 @@
                     </execution>
                 </executions>
             </plugin>
+               <!-- Test reporting -->
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven-surefire-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+            </plugin>
+        </plugins>
+    </reporting>
     <repositories>
         <repository>
             <id>central</id>

--- a/src/main/java/com/kodedu/service/DirectoryService.java
+++ b/src/main/java/com/kodedu/service/DirectoryService.java
@@ -12,6 +12,12 @@ import java.util.function.Supplier;
  * Created by usta on 25.12.2014.
  */
 public interface DirectoryService {
+    public final static String label = "core::service::DirectoryService";
+
+    /**
+     * Notify a working directory update. Sends a nullable {@link java.nio.file.Path}.
+     */
+    public final static String WORKING_DIRECTORY_UPDATE_EVENT = "event::directory::workingdirectory::update";
 
     public DirectoryChooser newDirectoryChooser(String title);
 

--- a/src/main/java/com/kodedu/service/EventService.java
+++ b/src/main/java/com/kodedu/service/EventService.java
@@ -1,0 +1,72 @@
+package com.kodedu.service;
+
+import java.util.Date;
+import java.util.function.Consumer;
+
+/**
+ * Used to share state changes accross the application
+ * @author Ayowel
+ * @since RC-SNAPSHOT
+ */
+public interface EventService {
+    /**
+     * The default service label to use
+     */
+    public final static String label = "core::service::EventService";
+
+    /**
+     * Propagate an event to all subscribed listeners
+     * @param label
+     *   The label of the event to subscribe to.
+     *   Label have scopes separated with :: scopes must be alpha-numerical
+     * @param data The dataset associated to the dispatched event
+     */
+    public void sendEvent(String label, Object data);
+
+    /**
+     * Subscribe to receive event notifications
+     * @param eventLabel The name of the event to listen for. May use a whole-scope wildcard with * instead of a scope's name
+     * @param callback A consumer to call when the event is triggered
+     * @return An event subscription object used to unsubscribe if needs be
+     * @see #sendEvent(String, Object)
+     */
+    public Subscription subscribe(String eventLabel, Consumer<Event> callback);
+
+    /**
+     * Stop receiving event notifications for a subscription
+     * @param subscription The event subscription to cancel
+     */
+    public void unsubscribe(Subscription subscription);
+
+    /**
+     * Represents a subscription to an event
+     * @author Ayowel
+     * @since RC-SNAPSHOT
+     */
+    public interface Subscription { }
+
+    /**
+     * Event object
+     * @author Ayowel
+     * @since RC-SNAPSHOT
+     * @param <T> The data type propagated by the event
+     */
+    public interface Event {
+        /**
+         * The label of the event
+         * @return
+         */
+        public String getLabel();
+        /**
+         * The event's payload
+         * @return
+         */
+        public Object getData();
+
+        /**
+         * The event's creation timestamp
+         * @return
+         */
+        public Date getTimestamp();
+    }
+}

--- a/src/main/java/com/kodedu/service/FileWatchService.java
+++ b/src/main/java/com/kodedu/service/FileWatchService.java
@@ -8,6 +8,7 @@ import java.util.Map;
  * Created by usta on 31.12.2014.
  */
 public interface FileWatchService {
+    public final static String label = "core::service::FileWatch";
 
     public void reCreateWatchService();
 

--- a/src/main/java/com/kodedu/service/ParserService.java
+++ b/src/main/java/com/kodedu/service/ParserService.java
@@ -9,6 +9,7 @@ import java.util.Optional;
  * Created by usta on 16.12.2014.
  */
 public interface ParserService {
+    public final static String label = "core::service::Parser";
 
     public Optional<String> toIncludeBlock(List<File> dropFiles);
 

--- a/src/main/java/com/kodedu/service/PathFinderService.java
+++ b/src/main/java/com/kodedu/service/PathFinderService.java
@@ -6,6 +6,7 @@ import java.nio.file.Path;
  * Created by usta on 20.05.2015.
  */
 public interface PathFinderService {
+    public final static String label = "core::service::PathFinder";
 
     public Path findPath(String uri, Integer parent);
 }

--- a/src/main/java/com/kodedu/service/PathOrderService.java
+++ b/src/main/java/com/kodedu/service/PathOrderService.java
@@ -6,6 +6,7 @@ import java.nio.file.Path;
  * Created by usta on 01.01.2015.
  */
 public interface PathOrderService {
+    public final static String label = "core::service::PathOrder";
 
     public int comparePaths(Path first, Path second);
 

--- a/src/main/java/com/kodedu/service/PathResolverService.java
+++ b/src/main/java/com/kodedu/service/PathResolverService.java
@@ -6,6 +6,7 @@ import java.nio.file.Path;
  * Created by usta on 07.09.2014.
  */
 public interface PathResolverService {
+    public final static String label = "core::service::PathResolver";
 
     public boolean isPDF(Path path);
 
@@ -24,7 +25,6 @@ public interface PathResolverService {
     public boolean isViewable(Path path);
 
     public boolean isOffice(Path path);
-
 
     public boolean isBook(Path path);
 

--- a/src/main/java/com/kodedu/service/SampleBookService.java
+++ b/src/main/java/com/kodedu/service/SampleBookService.java
@@ -6,6 +6,7 @@ import java.nio.file.Path;
  * Created by usta on 02.09.2014.
  */
 public interface SampleBookService {
+    public final static String label = "core::service::SampleBook";
 
     public void produceSampleBook(Path configPath, Path outputPath);
 }

--- a/src/main/java/com/kodedu/service/ThreadService.java
+++ b/src/main/java/com/kodedu/service/ThreadService.java
@@ -13,6 +13,7 @@ import java.util.function.Supplier;
  * Created by usta on 25.12.2014.
  */
 public interface ThreadService {
+    public final static String label = "core::service::ThreadService";
 
     public ScheduledFuture<?> schedule(Runnable runnable, long delay, TimeUnit timeUnit);
 

--- a/src/main/java/com/kodedu/service/cache/BinaryCacheService.java
+++ b/src/main/java/com/kodedu/service/cache/BinaryCacheService.java
@@ -6,6 +6,8 @@ import java.awt.image.BufferedImage;
  * Created by usta on 12.06.2016.
  */
 public interface BinaryCacheService {
+    public final static String label = "core::service::cache::BinaryCache";
+
     public String putBinary(String key, byte[] bytes);
 
     public CacheData getCacheData(String key);

--- a/src/main/java/com/kodedu/service/cache/impl/BinaryCacheServiceImpl.java
+++ b/src/main/java/com/kodedu/service/cache/impl/BinaryCacheServiceImpl.java
@@ -28,20 +28,20 @@ import java.util.concurrent.atomic.AtomicLong;
 /**
  * Created by usta on 12.06.2016.
  */
-@Component
+@Component(BinaryCacheService.label)
 public class BinaryCacheServiceImpl implements BinaryCacheService {
 
     private final long maximumSize = 50 * 1024 * 1024;
     private final AtomicLong totalSize = new AtomicLong(0);
     private final ConcurrentHashMap<String, CacheData> cache = new ConcurrentHashMap<>();
-    private final ThreadService threadService;
     private final Current current;
+    @Autowired
+    private ThreadService threadService;
 
     private Logger logger = LoggerFactory.getLogger(BinaryCacheService.class);
 
     @Autowired
-    public BinaryCacheServiceImpl(ThreadService threadService, Current current) {
-        this.threadService = threadService;
+    public BinaryCacheServiceImpl(Current current) {
         this.current = current;
     }
 
@@ -132,7 +132,7 @@ public class BinaryCacheServiceImpl implements BinaryCacheService {
                 .ifPresent(aLong -> totalSize.addAndGet(-aLong));
 
         cache.put(key, new InMemoryDAta(key, bytes));
-        long length = totalSize.addAndGet(bytes.length);
+        totalSize.addAndGet(bytes.length);
     }
 
     private boolean hasCacheFor(byte[] bytes) {

--- a/src/main/java/com/kodedu/service/extension/MathJaxService.java
+++ b/src/main/java/com/kodedu/service/extension/MathJaxService.java
@@ -7,8 +7,8 @@ import org.springframework.stereotype.Component;
 /**
  * Created by usta on 25.12.2014.
  */
-@Component
 public interface MathJaxService {
+    public final static String label = "core::service::extension::MathJax";
 
     public void reload();
 

--- a/src/main/java/com/kodedu/service/extension/MermaidService.java
+++ b/src/main/java/com/kodedu/service/extension/MermaidService.java
@@ -1,5 +1,6 @@
 package com.kodedu.service.extension;
 
 public interface MermaidService extends DefaultSettings {
+    public final static String label = "core::service::extension::Mermaid";
     public void createMermaidDiagram(String mermaidContent, String type, String imagesDir, String imageTarget, String nodename, boolean rerender);
 }

--- a/src/main/java/com/kodedu/service/extension/PlantUmlService.java
+++ b/src/main/java/com/kodedu/service/extension/PlantUmlService.java
@@ -4,7 +4,6 @@ package com.kodedu.service.extension;
  * Created by usta on 25.12.2014.
  */
 public interface PlantUmlService {
-
+    public final static String label = "core::service::extension::PlantUml";
     public void plantUml(String uml, String type, String imagesDir, String imageTarget, String nodename, String options);
-
 }

--- a/src/main/java/com/kodedu/service/extension/TreeService.java
+++ b/src/main/java/com/kodedu/service/extension/TreeService.java
@@ -4,8 +4,7 @@ package com.kodedu.service.extension;
  * Created by usta on 25.12.2014.
  */
 public interface TreeService extends DefaultSettings {
-
+    public final static String label = "core::service::extension::Tree";
     public void createFileTree(String tree, String type, String imagesDir, String imageTarget, String nodename);
-
     public void createHighlightFileTree(String tree, String type, String imagesDir, String imageTarget, String nodename);
 }

--- a/src/main/java/com/kodedu/service/extension/impl/MathJaxServiceImpl.java
+++ b/src/main/java/com/kodedu/service/extension/impl/MathJaxServiceImpl.java
@@ -29,16 +29,19 @@ import java.util.Objects;
 /**
  * Created by usta on 25.12.2014.
  */
-@Component
+@Component(MathJaxService.label)
 public class MathJaxServiceImpl implements MathJaxService {
 
     private final Logger logger = LoggerFactory.getLogger(MathJaxService.class);
 
     private final ApplicationController controller;
     private final Current current;
-    private final ThreadService threadService;
-    private final BinaryCacheService binaryCacheService;
     private final ExtensionConfigBean extensionConfigBean;
+    @Autowired
+    private ThreadService threadService;
+    @Autowired
+    private BinaryCacheService binaryCacheService;
+
     private WebView webView;
     private boolean initialized;
 
@@ -46,11 +49,9 @@ public class MathJaxServiceImpl implements MathJaxService {
     private String mathjaxUrl;
 
     @Autowired
-    public MathJaxServiceImpl(final ApplicationController controller, final Current current, ThreadService threadService, BinaryCacheService binaryCacheService, ExtensionConfigBean extensionConfigBean) {
+    public MathJaxServiceImpl(final ApplicationController controller, final Current current, ExtensionConfigBean extensionConfigBean) {
         this.controller = controller;
         this.current = current;
-        this.threadService = threadService;
-        this.binaryCacheService = binaryCacheService;
         this.extensionConfigBean = extensionConfigBean;
     }
 
@@ -81,6 +82,7 @@ public class MathJaxServiceImpl implements MathJaxService {
         });
     }
 
+    @Override
     public void reload() {
         this.load();
     }
@@ -89,6 +91,7 @@ public class MathJaxServiceImpl implements MathJaxService {
         return getWebView().getEngine();
     }
 
+    @Override
     public void processFormula(String formula, String imagesDir, String imageTarget) {
 
         threadService.runActionLater(() -> {
@@ -104,10 +107,12 @@ public class MathJaxServiceImpl implements MathJaxService {
         });
     }
 
+    @Override
     public JSObject getWindow() {
         return (JSObject) webEngine().executeScript("window");
     }
 
+    @Override
     public WebView getWebView() {
         if (Objects.isNull(webView)) {
             webView = new WebView();
@@ -123,6 +128,7 @@ public class MathJaxServiceImpl implements MathJaxService {
         return webView;
     }
 
+    @Override
     public void snapshotFormula(String formula, String imagesDir, String imageTarget) {
 
         try {

--- a/src/main/java/com/kodedu/service/extension/impl/MermaidServiceImpl.java
+++ b/src/main/java/com/kodedu/service/extension/impl/MermaidServiceImpl.java
@@ -28,16 +28,18 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
-@Component
+@Component(MermaidService.label)
 public class MermaidServiceImpl implements MermaidService {
 
     private final Logger logger = LoggerFactory.getLogger(MermaidService.class);
 
     private Current current;
     private ApplicationController controller;
-    private ThreadService threadService;
-    private final BinaryCacheService binaryCacheService;
     private final ExtensionConfigBean extensionConfigBean;
+    @Autowired
+    private ThreadService threadService;
+    @Autowired
+    private BinaryCacheService binaryCacheService;
 
     @Value("${application.mermaid.url}")
     private String mermaidUrl;
@@ -45,16 +47,13 @@ public class MermaidServiceImpl implements MermaidService {
     private Map<String, Integer> rerenderMap = new ConcurrentHashMap<>();
 
     @Autowired
-    public MermaidServiceImpl(final Current current, final ApplicationController controller,
-                          final ThreadService threadService,
-                          BinaryCacheService binaryCacheService, ExtensionConfigBean extensionConfigBean) {
+    public MermaidServiceImpl(final Current current, final ApplicationController controller, ExtensionConfigBean extensionConfigBean) {
         this.current = current;
         this.controller = controller;
-        this.threadService = threadService;
-        this.binaryCacheService = binaryCacheService;
         this.extensionConfigBean = extensionConfigBean;
     }
 
+    @Override
     public void createMermaidDiagram(String mermaidContent, String type, String imagesDir, String imageTarget, String nodename, boolean rerender) {
         Objects.requireNonNull(imageTarget);
 

--- a/src/main/java/com/kodedu/service/extension/impl/PlantUmlServiceImpl.java
+++ b/src/main/java/com/kodedu/service/extension/impl/PlantUmlServiceImpl.java
@@ -4,7 +4,6 @@ import com.kodedu.config.ExtensionConfigBean;
 import com.kodedu.controller.ApplicationController;
 import com.kodedu.helper.IOHelper;
 import com.kodedu.other.Current;
-import com.kodedu.service.DirectoryService;
 import com.kodedu.service.ThreadService;
 import com.kodedu.service.cache.BinaryCacheService;
 import com.kodedu.service.extension.PlantUmlService;
@@ -29,29 +28,27 @@ import static java.util.Objects.nonNull;
 /**
  * Created by usta on 25.12.2014.
  */
-@Component
+@Component(PlantUmlService.label)
 public class PlantUmlServiceImpl implements PlantUmlService {
 
     private final Logger logger = LoggerFactory.getLogger(PlantUmlService.class);
 
     private final Current current;
     private final ApplicationController controller;
-    private final ThreadService threadService;
-    private final BinaryCacheService binaryCacheService;
     private final ExtensionConfigBean extensionConfigBean;
-
-    private final DirectoryService directoryService;
+    @Autowired
+    private ThreadService threadService;
+    @Autowired
+    private BinaryCacheService binaryCacheService;
 
     @Autowired
-    public PlantUmlServiceImpl(final Current current, final ApplicationController controller, final ThreadService threadService, BinaryCacheService binaryCacheService, ExtensionConfigBean extensionConfigBean, DirectoryService directoryService) {
+    public PlantUmlServiceImpl(final Current current, final ApplicationController controller, ExtensionConfigBean extensionConfigBean) {
         this.current = current;
         this.controller = controller;
-        this.threadService = threadService;
-        this.binaryCacheService = binaryCacheService;
         this.extensionConfigBean = extensionConfigBean;
-        this.directoryService = directoryService;
     }
 
+    @Override
     public synchronized void plantUml(String uml, String type, String imagesDir, String imageTarget, String nodename, String options) {
         Objects.requireNonNull(imageTarget);
 

--- a/src/main/java/com/kodedu/service/extension/impl/TreeServiceImpl.java
+++ b/src/main/java/com/kodedu/service/extension/impl/TreeServiceImpl.java
@@ -39,36 +39,33 @@ import java.util.stream.Collectors;
 /**
  * Created by usta on 25.12.2014.
  */
-@Component
+@Component(TreeService.label)
 public class TreeServiceImpl implements TreeService {
-
     private final Logger logger = LoggerFactory.getLogger(TreeService.class);
 
     private Current current;
     private ApplicationController controller;
-    private ThreadService threadService;
-    private AwesomeService awesomeService;
-    private final BinaryCacheService binaryCacheService;
     private final ExtensionConfigBean extensionConfigBean;
+    @Autowired
+    private ThreadService threadService;
+    @Autowired
+    private BinaryCacheService binaryCacheService;
+    @Autowired
+    private AwesomeService awesomeService;
 
     Pattern pattern = Pattern.compile("^(addw|minw|setw|addh|minh|seth|scale):\\s*(\\d+)$");
 
     @Value("${application.treeview.url}")
     private String treeviewUrl;
-    private WebView treeview;
-    private boolean initialized;
 
     @Autowired
-    public TreeServiceImpl(final Current current, final ApplicationController controller, final ThreadService threadService,
-                       final AwesomeService awesomeService, BinaryCacheService binaryCacheService, ExtensionConfigBean extensionConfigBean) {
+    public TreeServiceImpl(final Current current, final ApplicationController controller, ExtensionConfigBean extensionConfigBean) {
         this.current = current;
         this.controller = controller;
-        this.threadService = threadService;
-        this.awesomeService = awesomeService;
-        this.binaryCacheService = binaryCacheService;
         this.extensionConfigBean = extensionConfigBean;
     }
 
+    @Override
     public void createFileTree(String tree, String type, String imagesDir, String imageTarget, String nodename) {
 
         Objects.requireNonNull(imageTarget);
@@ -249,6 +246,7 @@ public class TreeServiceImpl implements TreeService {
         return fileView;
     }
 
+    @Override
     public void createHighlightFileTree(String tree, String type, String imagesDir, String imageTarget, String nodename) {
         Objects.requireNonNull(imageTarget);
 

--- a/src/main/java/com/kodedu/service/impl/EventServiceImpl.java
+++ b/src/main/java/com/kodedu/service/impl/EventServiceImpl.java
@@ -1,0 +1,240 @@
+package com.kodedu.service.impl;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.kodedu.service.EventService;
+import com.kodedu.service.ThreadService;
+
+@Component(EventService.label)
+public class EventServiceImpl implements EventService {
+
+    /**
+     * Map event labels to the associated subscriptions
+     */
+    private final Map<String, List<Subscription>> subscriptionsMap = new HashMap<String, List<Subscription>>();
+
+    /**
+     * String used to split event scopes
+     */
+    private final String EVENT_SCOPE_SEPARATOR = "::";
+
+    /**
+     * Logger for {@link EventServiceImpl}
+     */
+    private static Logger logger = LoggerFactory.getLogger(EventServiceImpl.class);
+
+    /**
+     * The thread service instance to use when scheduling notifications
+     */
+    @Autowired
+    private ThreadService threadService;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void sendEvent(String label, Object data) {
+        Event event = new Event(label, data);
+        getMatchingSubscriptionsCallbacks(label).forEach(consumer -> threadService.runActionLater(() -> {
+            try {
+                consumer.accept(event);
+            } catch (Exception e) {
+                logger.debug(String.format("An exception occured while dispatching an event with label %s", label), e);
+            }
+        }));
+    }
+
+    /**
+     * Gather all unique callbacks to call for an event dispatch
+     * @param eventLabel The qualifier of the event whose listeners should be looked-up
+     * @return A set of Consumers matching the label
+     */
+    private Set<Consumer<EventService.Event>> getMatchingSubscriptionsCallbacks(String eventLabel) {
+        Set<Consumer<EventService.Event>> matchSet = new HashSet<Consumer<EventService.Event>>();
+        String labelExplorer = "";
+        synchronized (subscriptionsMap) {
+            for(String scope: eventLabel.split(EVENT_SCOPE_SEPARATOR)) {
+                labelExplorer += (labelExplorer.length()>0 ? EVENT_SCOPE_SEPARATOR : "") + scope;
+                if(subscriptionsMap.containsKey(labelExplorer)) {
+                    matchSet.addAll(
+                            subscriptionsMap.get(labelExplorer).stream()
+                            .map(s -> s.getConsumer())
+                            .collect(Collectors.toCollection(HashSet::new)));
+                }
+            }
+        }
+        return matchSet;
+    }
+
+    /**
+     * Ensure that an event label is well-formed
+     * @param label The event to dispatch
+     * @return Whether the label is well-formed
+     */
+    private boolean isLabelValid(String label) {
+        if(label.startsWith(EVENT_SCOPE_SEPARATOR) || label.endsWith(EVENT_SCOPE_SEPARATOR)) {
+            return false;
+        }
+        for(String scope: label.split(EVENT_SCOPE_SEPARATOR)) {
+            if(!scope.matches("[a-zA-Z][a-zA-Z0-9]+")) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public EventService.Subscription subscribe(String eventLabel, Consumer<EventService.Event> callback) {
+        if(!isLabelValid(eventLabel)) {
+            // FIXME: Should throw an extension of IllegalFormatException
+            IllegalArgumentException exception = new IllegalArgumentException(String.format("%s%s", "Invalid event label received: ", eventLabel));
+            //logger.error("Subscription error", exception);
+            throw exception;
+        }
+
+        Subscription listenerSubscription = new Subscription(eventLabel, callback);
+        synchronized (subscriptionsMap) {
+            if(subscriptionsMap.containsKey(eventLabel)) {
+                // Premature optimization: Add first so that short-lived subscriptions end up being found quickly @ removal
+                subscriptionsMap.get(eventLabel).add(0, listenerSubscription);
+            } else {
+                List<Subscription> subscriptionList = new LinkedList<Subscription>();
+                subscriptionList.add(listenerSubscription);
+                subscriptionsMap.put(eventLabel, subscriptionList);
+            }
+        }
+        return listenerSubscription;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void unsubscribe(EventService.Subscription subscription) {
+        if (!(subscription instanceof Subscription)) {
+            // Might happen if several EventService implementations are provided and swap between one another
+            logger.error("Attempted to cancel a subscription provided by a different EventService Implementation");
+            return;
+        }
+        Subscription internalSubscription = (Subscription) subscription;
+        String subscriptionLabel = internalSubscription.getLabel();
+        synchronized (subscriptionsMap) {
+            if(subscriptionsMap.containsKey(subscriptionLabel)) {
+                List<Subscription> subscriptionList = subscriptionsMap.get(subscriptionLabel);
+                if(subscriptionList.remove(internalSubscription)) {
+                    // Do not clean-up on empty list, the memory impact
+                    // does not justify the additional complexity and processing
+                    return;
+                }
+            }
+        }
+        // We reach this point only if the subscription was not in store
+        logger.error(String.format("%s%s", "Attempted to cancel a subscription but it could not be found for label ", internalSubscription.getLabel() ));
+    }
+
+    private class Event implements EventService.Event {
+        /**
+         * The Event's label
+         */
+        private final String label;
+
+        /**
+         * The Event's data
+         */
+        private final Object data;
+
+        /**
+         * The Event's creation timestamp
+         */
+        private final Date timestamp;
+
+        /**
+         * Base Event constructor
+         * @param label The Event's label
+         * @param data The Event's data
+         */
+        public Event(String label, Object data) {
+            this.label = label;
+            this.data = data;
+            this.timestamp = new Date();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getLabel() {
+            return label;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Object getData() {
+            return data;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Date getTimestamp() {
+            return this.timestamp;
+        }
+
+    }
+
+    private class Subscription implements EventService.Subscription {
+        /**
+         * The Event label handled by the subscription
+         */
+        private String label;
+        /**
+         * The Consumer used by the subscriptions
+         */
+        private Consumer<EventService.Event> consumer;
+
+        /**
+         * Constructor
+         * @param label
+         * @param consumer
+         */
+        public Subscription(String label, Consumer<EventService.Event> consumer) {
+            this.label = label;
+            this.consumer = consumer;
+        }
+
+        /**
+         * Get the subscription's event label
+         * @return The event label
+         */
+        public String getLabel() {
+            return this.label;
+        }
+
+        /**
+         * Get the subscription's callback
+         * @return The callback
+         */
+        public Consumer<EventService.Event> getConsumer() {
+            return this.consumer;
+        }
+    }
+}

--- a/src/main/java/com/kodedu/service/impl/FileWatchServiceImpl.java
+++ b/src/main/java/com/kodedu/service/impl/FileWatchServiceImpl.java
@@ -28,17 +28,17 @@ import static java.nio.file.StandardWatchEventKinds.*;
 /**
  * Created by usta on 31.12.2014.
  */
-@Component
+@Component(FileWatchService.label)
 public class FileWatchServiceImpl implements FileWatchService {
-
     private final Logger logger = LoggerFactory.getLogger(FileWatchService.class);
 
     private WatchService watcher = null;
     private final ApplicationController controller;
-    private final ThreadService threadService;
-
     @Autowired
     private FileBrowseService fileBrowseService;
+
+    @Autowired
+    private ThreadService threadService;
 
     @Autowired
     private ApplicationContext applicationContext;
@@ -47,9 +47,8 @@ public class FileWatchServiceImpl implements FileWatchService {
     private final PathMapper pathMapper;
 
     @Autowired
-    public FileWatchServiceImpl(ApplicationController controller, ThreadService threadService, PathMapper pathMapper) {
+    public FileWatchServiceImpl(ApplicationController controller, PathMapper pathMapper) {
         this.controller = controller;
-        this.threadService = threadService;
         this.pathMapper = pathMapper;
     }
 
@@ -123,6 +122,7 @@ public class FileWatchServiceImpl implements FileWatchService {
             for (WatchEvent<?> event : watchEvents) {
                 WatchEvent.Kind<?> kind = event.kind();
                 if (kind == ENTRY_MODIFY && event.count() == 1) {
+                    @SuppressWarnings("unchecked")
                     WatchEvent<Path> ev = (WatchEvent<Path>) event;
                     Path modifiedPath = path.resolve(ev.context());
                     ObservableList<Tab> tabs = controller.getTabPane().getTabs();
@@ -151,6 +151,7 @@ public class FileWatchServiceImpl implements FileWatchService {
                 Path changedPath = null;
 
                 if (watchEvents.size() == 1) {
+                    @SuppressWarnings("unchecked")
                     WatchEvent<Path> ev = (WatchEvent<Path>) watchEvents.get(0);
                     changedPath = path.resolve(ev.context());
                     pathMapper.addPath(changedPath);

--- a/src/main/java/com/kodedu/service/impl/ParserServiceImpl.java
+++ b/src/main/java/com/kodedu/service/impl/ParserServiceImpl.java
@@ -3,7 +3,6 @@ package com.kodedu.service.impl;
 import com.kodedu.controller.ApplicationController;
 import com.kodedu.helper.IOHelper;
 import com.kodedu.other.Constants;
-import com.kodedu.other.Current;
 import com.kodedu.service.DirectoryService;
 import com.kodedu.service.ParserService;
 import com.kodedu.service.PathResolverService;
@@ -33,23 +32,18 @@ import java.util.stream.Collectors;
 /**
  * Created by usta on 16.12.2014.
  */
-@Component
+@Component(ParserService.label)
 public class ParserServiceImpl implements ParserService {
-
-    private final ApplicationController asciiDocController;
-    private final Current current;
-    private final PathResolverService pathResolver;
-    private final DirectoryService directoryService;
-
-    private Logger logger = LoggerFactory.getLogger(ParserService.class);
+    @Autowired
+    private DirectoryService directoryService;
 
     @Autowired
-    public ParserServiceImpl(final ApplicationController asciiDocController, final Current current, final PathResolverService pathResolver, DirectoryService directoryService) {
-        this.asciiDocController = asciiDocController;
-        this.current = current;
-        this.pathResolver = pathResolver;
-        this.directoryService = directoryService;
-    }
+    private PathResolverService pathResolverService;
+
+    @Autowired
+    private ApplicationController asciiDocController;
+
+    private Logger logger = LoggerFactory.getLogger(ParserService.class);
 
     @Override
     public Optional<String> toIncludeBlock(List<File> dropFiles) {
@@ -70,7 +64,6 @@ public class ParserServiceImpl implements ParserService {
 
     @Override
     public Optional<String> toImageBlock(Image image) {
-
         Path currentPath = directoryService.currentParentOrWorkdir();
         IOHelper.createDirectories(currentPath.resolve("images"));
 
@@ -102,7 +95,7 @@ public class ParserServiceImpl implements ParserService {
 
         Path workDir = directoryService.workingDirectory();
         IOHelper.createDirectories(workDir.resolve("images"));
-        List<Path> paths = dropFiles.stream().map(File::toPath).filter(pathResolver::isImage).collect(Collectors.toList());
+        List<Path> paths = dropFiles.stream().map(File::toPath).filter(pathResolverService::isImage).collect(Collectors.toList());
 
         List<String> buffer = new LinkedList<>();
 

--- a/src/main/java/com/kodedu/service/impl/PathFinderServiceImpl.java
+++ b/src/main/java/com/kodedu/service/impl/PathFinderServiceImpl.java
@@ -15,17 +15,17 @@ import java.util.stream.IntStream;
 /**
  * Created by usta on 20.05.2015.
  */
-@Component("pathFinder")
+@Component(PathFinderService.label)
 @Scope("prototype")
 public class PathFinderServiceImpl implements PathFinderService {
-
     private final Current current;
-    private final DirectoryService directoryService;
 
     @Autowired
-    public PathFinderServiceImpl(Current current, DirectoryService directoryService) {
+    private DirectoryService directoryService;
+
+    @Autowired
+    public PathFinderServiceImpl(final Current current) {
         this.current = current;
-        this.directoryService = directoryService;
     }
 
     @Override

--- a/src/main/java/com/kodedu/service/impl/PathOrderServiceImpl.java
+++ b/src/main/java/com/kodedu/service/impl/PathOrderServiceImpl.java
@@ -10,9 +10,8 @@ import java.nio.file.Path;
 /**
  * Created by usta on 01.01.2015.
  */
-@Component
+@Component(PathOrderService.label)
 public class PathOrderServiceImpl implements PathOrderService {
-
     @Override
     public int comparePaths(Path first, Path second) {
 

--- a/src/main/java/com/kodedu/service/impl/PathResolverServiceImpl.java
+++ b/src/main/java/com/kodedu/service/impl/PathResolverServiceImpl.java
@@ -3,8 +3,6 @@ package com.kodedu.service.impl;
 import com.kodedu.helper.IOHelper;
 import com.kodedu.service.PathResolverService;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import java.nio.file.FileSystems;
@@ -15,11 +13,8 @@ import java.nio.file.PathMatcher;
 /**
  * Created by usta on 07.09.2014.
  */
-@Component
+@Component(PathResolverService.label)
 public class PathResolverServiceImpl implements PathResolverService {
-
-    private final Logger logger = LoggerFactory.getLogger(PathResolverService.class);
-
     private final PathMatcher pdfMatcher = FileSystems.getDefault().getPathMatcher("glob:**.pdf");
     private final PathMatcher markdownMatcher = FileSystems.getDefault().getPathMatcher("glob:{**.md,**.markdown}");
     private final PathMatcher htmlMatcher = FileSystems.getDefault().getPathMatcher("glob:**.{htm,html}");
@@ -86,6 +81,7 @@ public class PathResolverServiceImpl implements PathResolverService {
                 || isHTML(path)
                 || isXML(path)
                 || isMarkdown(path);
+
     }
 
     @Override

--- a/src/main/java/com/kodedu/service/impl/SampleBookServiceImpl.java
+++ b/src/main/java/com/kodedu/service/impl/SampleBookServiceImpl.java
@@ -14,9 +14,8 @@ import java.nio.file.Path;
 /**
  * Created by usta on 02.09.2014.
  */
-@Component
+@Component(SampleBookService.label)
 public class SampleBookServiceImpl implements SampleBookService {
-
     private final Logger logger = LoggerFactory.getLogger(SampleBookService.class);
 
     @Override

--- a/src/main/java/com/kodedu/service/impl/ThreadServiceImpl.java
+++ b/src/main/java/com/kodedu/service/impl/ThreadServiceImpl.java
@@ -3,6 +3,7 @@ package com.kodedu.service.impl;
 import javafx.application.Platform;
 import javafx.concurrent.Task;
 import javafx.event.ActionEvent;
+
 import org.springframework.stereotype.Component;
 
 import com.kodedu.service.Buff;
@@ -16,9 +17,8 @@ import java.util.function.Supplier;
 /**
  * Created by usta on 25.12.2014.
  */
-@Component
+@Component(ThreadService.label)
 public class ThreadServiceImpl implements ThreadService {
-
     private final ExecutorService threadPollWorker;
     private final ScheduledExecutorService scheduledWorker;
     private final ConcurrentHashMap<String, Buff> buffMap;

--- a/src/main/java/com/kodedu/service/shortcut/NoneShortcutService.java
+++ b/src/main/java/com/kodedu/service/shortcut/NoneShortcutService.java
@@ -4,5 +4,5 @@ package com.kodedu.service.shortcut;
  * Created by usta on 06.07.2015.
  */
 public interface NoneShortcutService extends ShortcutService {
-	
+
 }

--- a/src/main/java/com/kodedu/service/ui/AwesomeService.java
+++ b/src/main/java/com/kodedu/service/ui/AwesomeService.java
@@ -8,5 +8,7 @@ import java.nio.file.Path;
  */
 public interface AwesomeService {
 
+    public final static String label = "core::service::ui::AwesomeService";
+
     public Node getIcon(final Path path);
 }

--- a/src/main/java/com/kodedu/service/ui/EditorService.java
+++ b/src/main/java/com/kodedu/service/ui/EditorService.java
@@ -9,5 +9,6 @@ import javafx.scene.Node;
  * Created by usta on 25.12.2014.
  */
 public interface EditorService {
+    public final static String label = "core::service::ui::EditorService";
     public Node createEditorVBox(EditorPane editorPane, MyTab myTab);
 }

--- a/src/main/java/com/kodedu/service/ui/FileBrowseService.java
+++ b/src/main/java/com/kodedu/service/ui/FileBrowseService.java
@@ -10,6 +10,8 @@ import java.nio.file.Path;
  */
 public interface FileBrowseService {
 
+    public final static String label = "core::service::ui::FileBrowseService";
+
     public void cleanRefresh();
 
     public void refresh();

--- a/src/main/java/com/kodedu/service/ui/IndikatorService.java
+++ b/src/main/java/com/kodedu/service/ui/IndikatorService.java
@@ -4,9 +4,7 @@ package com.kodedu.service.ui;
  * Created by usta on 01.09.2014.
  */
 public interface IndikatorService {
-
+    public final static String label = "core::service::ui::IndikatorService";
     public void startProgressBar();
-
     public void stopProgressBar();
-
 }

--- a/src/main/java/com/kodedu/service/ui/TabService.java
+++ b/src/main/java/com/kodedu/service/ui/TabService.java
@@ -16,6 +16,8 @@ import com.kodedu.component.MyTab;
  */
 public interface TabService {
 
+    public final static String label = "core::service::ui::TabService";
+
     public void closeFirstNewTab();
 
     public void addTab(Path path, Runnable... runnables);

--- a/src/main/java/com/kodedu/service/ui/TooltipTimeFixService.java
+++ b/src/main/java/com/kodedu/service/ui/TooltipTimeFixService.java
@@ -4,5 +4,6 @@ package com.kodedu.service.ui;
  * Created by usta on 25.01.2015.
  */
 public interface TooltipTimeFixService {
+    public final static String label = "core::service::ui::TooltipTimeFixService";
     public void fix();
 }

--- a/src/main/java/com/kodedu/service/ui/impl/AwesomeServiceImpl.java
+++ b/src/main/java/com/kodedu/service/ui/impl/AwesomeServiceImpl.java
@@ -16,15 +16,11 @@ import java.nio.file.Path;
 /**
  * Created by usta on 16.12.2014.
  */
-@Component
+@Component(AwesomeService.label)
 public class AwesomeServiceImpl implements AwesomeService {
 
-    private final PathResolverService pathResolver;
-
     @Autowired
-    public AwesomeServiceImpl(final PathResolverService pathResolver) {
-        this.pathResolver = pathResolver;
-    }
+    private PathResolverService pathResolver;
 
     @Override
     public Node getIcon(final Path path) {

--- a/src/main/java/com/kodedu/service/ui/impl/EditorServiceImpl.java
+++ b/src/main/java/com/kodedu/service/ui/impl/EditorServiceImpl.java
@@ -5,7 +5,6 @@ import com.kodedu.component.LabelBuilt;
 import com.kodedu.component.MenuItemBuilt;
 import com.kodedu.component.MyTab;
 import com.kodedu.controller.ApplicationController;
-import com.kodedu.other.Current;
 import com.kodedu.other.DocumentMode;
 import com.kodedu.service.shortcut.ShortcutProvider;
 import com.kodedu.service.ui.EditorService;
@@ -13,8 +12,17 @@ import com.kodedu.service.ui.EditorService;
 import javafx.collections.ObservableList;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
-import javafx.scene.control.*;
-import javafx.scene.layout.*;
+import javafx.scene.control.Label;
+import javafx.scene.control.Menu;
+import javafx.scene.control.MenuButton;
+import javafx.scene.control.MenuItem;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.layout.FlowPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.VBox;
+
 import org.kordamp.ikonli.fontawesome.FontAwesome;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -28,17 +36,11 @@ import java.util.stream.Collectors;
 /**
  * Created by usta on 25.12.2014.
  */
-@Component
+@Component(EditorService.label)
 public class EditorServiceImpl implements EditorService {
 
-    private final Current current;
-    private final ApplicationController controller;
-
     @Autowired
-    public EditorServiceImpl(final Current current, final ApplicationController controller) {
-        this.current = current;
-        this.controller = controller;
-    }
+    private ApplicationController controller;
 
     @Autowired
     private ShortcutProvider shortcutProvider;

--- a/src/main/java/com/kodedu/service/ui/impl/IndikatorServiceImpl.java
+++ b/src/main/java/com/kodedu/service/ui/impl/IndikatorServiceImpl.java
@@ -1,6 +1,5 @@
 package com.kodedu.service.ui.impl;
 
-import com.kodedu.component.HtmlPane;
 import com.kodedu.controller.ApplicationController;
 import com.kodedu.service.ThreadService;
 import com.kodedu.service.ui.IndikatorService;
@@ -13,23 +12,17 @@ import org.springframework.stereotype.Component;
 /**
  * Created by usta on 01.09.2014.
  */
-@Component
+@Component(IndikatorService.label)
 public class IndikatorServiceImpl implements IndikatorService {
 
-    private final ApplicationController applicationContoller;
-    private final ThreadService threadService;
-    private final HtmlPane htmlPane;
+    @Autowired
+    private ApplicationController applicationContoller;
 
     @Autowired
-    public IndikatorServiceImpl(final ApplicationController applicationContoller, final ThreadService threadService, HtmlPane htmlPane) {
-        this.applicationContoller = applicationContoller;
-        this.threadService = threadService;
-        this.htmlPane = htmlPane;
-    }
+    private ThreadService threadService;
 
     @Override
     public void startProgressBar() {
-
         threadService.runActionLater(() -> {
             ProgressBar progressBar = applicationContoller.getProgressBar();
             Timeline timeline = applicationContoller.getProgressBarTimeline();

--- a/src/main/java/com/kodedu/service/ui/impl/TabServiceImpl.java
+++ b/src/main/java/com/kodedu/service/ui/impl/TabServiceImpl.java
@@ -1,6 +1,10 @@
 package com.kodedu.service.ui.impl;
 
-import com.kodedu.component.*;
+import com.kodedu.component.AlertHelper;
+import com.kodedu.component.EditorPane;
+import com.kodedu.component.ImageTab;
+import com.kodedu.component.MenuItemBuilt;
+import com.kodedu.component.MyTab;
 import com.kodedu.config.StoredConfigBean;
 import com.kodedu.controller.ApplicationController;
 import com.kodedu.helper.IOHelper;
@@ -9,11 +13,8 @@ import com.kodedu.other.Current;
 import com.kodedu.other.ExtensionFilters;
 import com.kodedu.other.Item;
 import com.kodedu.service.DirectoryService;
-import com.kodedu.service.ParserService;
 import com.kodedu.service.PathResolverService;
 import com.kodedu.service.ThreadService;
-import com.kodedu.service.extension.AsciiTreeGenerator;
-import com.kodedu.service.shortcut.ShortcutProvider;
 import com.kodedu.service.ui.EditorService;
 import com.kodedu.service.ui.TabService;
 
@@ -22,7 +23,17 @@ import javafx.beans.value.ObservableObjectValue;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.scene.Node;
-import javafx.scene.control.*;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.ContextMenu;
+import javafx.scene.control.Label;
+import javafx.scene.control.MenuItem;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.control.SeparatorMenuItem;
+import javafx.scene.control.SingleSelectionModel;
+import javafx.scene.control.Tab;
+import javafx.scene.control.TabPane;
+import javafx.scene.control.Tooltip;
+import javafx.scene.control.TreeItem;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.MouseButton;
@@ -49,22 +60,25 @@ import java.util.stream.Collectors;
 /**
  * Created by usta on 25.12.2014.
  */
-@Component
+@Component(TabService.label)
 public class TabServiceImpl implements TabService {
 
     private final Logger logger = LoggerFactory.getLogger(TabService.class);
 
-    private final ApplicationController controller;
-    private final EditorService editorService;
-    private final PathResolverService pathResolver;
-    private final ThreadService threadService;
+    @Autowired
+    private ApplicationController controller;
+    @Autowired
+    private ThreadService threadService;
+    @Autowired
+    private EditorService editorService;
+    @Autowired
+    private DirectoryService directoryService;
+    @Autowired
+    private PathResolverService pathResolver;
+
     private final Current current;
-    private final DirectoryService directoryService;
     private final StoredConfigBean storedConfigBean;
-    private final ParserService parserService;
     private final ApplicationContext applicationContext;
-    private final ShortcutProvider shortcutProvider;
-    private final AsciiTreeGenerator asciiTreeGenerator;
 
     @Value("${application.editor.url}")
     private String editorUrl;
@@ -74,22 +88,11 @@ public class TabServiceImpl implements TabService {
 
     private ObservableList<Optional<Path>> closedPaths = FXCollections.observableArrayList();
 
-
     @Autowired
-    public TabServiceImpl(final ApplicationController controller, final EditorService editorService,
-                      final PathResolverService pathResolver, final ThreadService threadService, final Current current,
-                      final DirectoryService directoryService, StoredConfigBean storedConfigBean, ParserService parserService, ApplicationContext applicationContext, ShortcutProvider shortcutProvider, AsciiTreeGenerator asciiTreeGenerator) {
-        this.controller = controller;
-        this.editorService = editorService;
-        this.pathResolver = pathResolver;
-        this.threadService = threadService;
+    public TabServiceImpl(final Current current, StoredConfigBean storedConfigBean, ApplicationContext applicationContext) {
         this.current = current;
-        this.directoryService = directoryService;
         this.storedConfigBean = storedConfigBean;
-        this.parserService = parserService;
         this.applicationContext = applicationContext;
-        this.shortcutProvider = shortcutProvider;
-        this.asciiTreeGenerator = asciiTreeGenerator;
     }
 
     @Override
@@ -271,22 +274,6 @@ public class TabServiceImpl implements TabService {
                     event.consume();
             });
         });
-//
-//        MenuItem menuItem3 = new MenuItem("Close Unmodified");
-//        menuItem3.setOnAction(actionEvent -> {
-//
-//            ObservableList<Tab> clonedTabs = FXCollections.observableArrayList();
-//            clonedTabs.addAll(controller.getTabPane().getTabs());
-//
-//
-//            for (Tab clonedTab : clonedTabs) {
-//                MyTab myTab = (MyTab) clonedTab;
-//                if (!myTab.getTabText().contains(" *"))
-//                    threadService.runActionLater(()->{
-//                        myTab.close();
-//                    });
-//            }
-//        });
 
         MenuItem menuItem4 = new MenuItem("Select Next Tab");
         menuItem4.setOnAction(actionEvent -> {

--- a/src/main/java/com/kodedu/service/ui/impl/TooltipTimeFixServiceImpl.java
+++ b/src/main/java/com/kodedu/service/ui/impl/TooltipTimeFixServiceImpl.java
@@ -15,7 +15,7 @@ import java.lang.reflect.Field;
 /**
  * Created by usta on 25.01.2015.
  */
-@Component
+@Component(TooltipTimeFixService.label)
 public class TooltipTimeFixServiceImpl implements TooltipTimeFixService {
 
     private final Logger logger = LoggerFactory.getLogger(TooltipTimeFixService.class);

--- a/src/test/java/com/kodedu/service/impl/EventServiceTest.java
+++ b/src/test/java/com/kodedu/service/impl/EventServiceTest.java
@@ -1,0 +1,145 @@
+package com.kodedu.service.impl;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import javafx.util.Pair;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.event.Level;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.testfx.framework.junit5.ApplicationExtension;
+
+import com.kodedu.service.EventService;
+import com.kodedu.service.EventService.Event;
+import com.kodedu.service.EventService.Subscription;
+
+import io.github.netmikey.logunit.api.LogCapturer;
+
+@ExtendWith(ApplicationExtension.class)
+@SpringBootTest()
+@ContextConfiguration(classes= {EventServiceImpl.class, ThreadServiceImpl.class})
+public class EventServiceTest {
+    // FIXME: Tests rely on ThreadService implementation, making it compatible withs tests/mocks would make tests execution more reliable
+
+    /**
+     * Event Service object being tested
+     */
+    @Autowired
+    private EventService eventService;
+
+    /**
+     * Log auditing for Event service logs
+     */
+    @RegisterExtension
+    LogCapturer logs = LogCapturer.create().captureForType(EventServiceImpl.class, Level.DEBUG);
+
+    /**
+     * Ensure that base Bean loading functions are satisfied
+     */
+    @Test
+    void should_allow_subscription_and_unsubscription() {
+        String eventLabel = "test::event::basicUsage";
+        Subscription subscription = eventService.subscribe(eventLabel, e -> {});
+        Assertions.assertNotNull(subscription);
+        Assertions.assertDoesNotThrow(() -> eventService.unsubscribe(subscription));
+    }
+
+    /**
+     * Test that event subscriptions are honored
+     */
+    @Test
+    void should_notify_subscribed_events() {
+        String eventLabel = "test::event::simpleNotify";
+        List<Pair<String, Object>> callstack1 = new LinkedList<Pair<String, Object>>();
+        List<Pair<String, Object>> callstack2 = new LinkedList<Pair<String, Object>>();
+
+        // Add two event subscribers and ensure they are not called early
+        eventService.subscribe(eventLabel, e -> callstack1.add(new Pair<String, Object>(e.getLabel(), e.getData())));
+        eventService.subscribe(eventLabel, e -> callstack2.add(new Pair<String, Object>(e.getLabel(), e.getData())));
+        Assertions.assertEquals(0, callstack1.size());
+        Assertions.assertEquals(0, callstack2.size());
+
+        // Send an event and ensure both subscribers receive them
+        eventService.sendEvent(eventLabel, "payload");
+        Assertions.assertDoesNotThrow(() -> Thread.sleep(10));
+        Assertions.assertEquals(1, callstack1.size());
+        Assertions.assertEquals(1, callstack2.size());
+    }
+
+    /**
+     * Test handling of event subscribers with errors
+     */
+    @Test
+    void should_gracefully_handle_throwing_subscribers() {
+        String eventLabel = "test::event::simpleThrow";
+        String exceptionMessage = "0001_This is a test exception";
+        RuntimeException thrownException = new RuntimeException(exceptionMessage);
+
+        // Prepare consumer
+        eventService.subscribe(eventLabel, e -> {throw thrownException;});
+        Assertions.assertTrue(logs.getEvents().isEmpty());
+
+        // Send event to throwing consumer
+        eventService.sendEvent(eventLabel, "payload");
+        Assertions.assertDoesNotThrow(() -> Thread.sleep(10));
+        Assertions.assertTrue(logs.getEvents().stream().anyMatch(e -> e.getLevel() == Level.DEBUG && e.getThrowable() == thrownException));
+    }
+
+    /**
+     * Test invalid unsubscription parameters handling
+     */
+    @Test
+    void should_warn_of_invalid_unsubscription_attempts() {
+        Subscription unknownSubscription = new Subscription() {}; // inline class declaration
+        String eventLabel = "test::event::unsubscriptionTest";
+        Subscription knownSubscription = eventService.subscribe(eventLabel, e -> {});
+
+        // Regular unsubscribe, no error expected
+        eventService.unsubscribe(knownSubscription);
+        Assertions.assertTrue(logs.getEvents().isEmpty());
+
+        // Attempt to unsubscribe an already unsubscribed item
+        eventService.unsubscribe(knownSubscription);
+        Assertions.assertEquals(1, logs.getEvents().stream().count());
+
+        // Attempt to unsubscribe a subscription from a different EventService implementation
+        eventService.unsubscribe(unknownSubscription);
+        Assertions.assertEquals(2, logs.getEvents().stream().filter(e -> e.getLevel() == Level.ERROR).count());
+    }
+
+    /**
+     * Test several invalid subscription labels
+     */
+    @Test
+    void should_reject_invalid_subscription_labels() {
+        Consumer<Event> consumer = (Event e) -> {};
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            eventService.subscribe("", consumer);
+        });
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            eventService.subscribe("::", consumer);
+        });
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            eventService.subscribe("test::event::invalid::", consumer);
+        });
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            eventService.subscribe("test::event:::invalid", consumer);
+        });
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            eventService.subscribe("::test::event::invalid", consumer);
+        });
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            eventService.subscribe("3test::event::invalid::", consumer);
+        });
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            eventService.subscribe("test::event::invalid::*", consumer);
+        });
+    }
+}

--- a/src/test/resources/config.properties
+++ b/src/test/resources/config.properties
@@ -1,0 +1,1 @@
+org.slf4j.simpleLogger.defaultLogLevel = debug


### PR DESCRIPTION
See #519

* Add unit tests support
* Add an event service
* Set explicit component names across the application

The event service has an example use-case to notify of a working directory update across the application and lower coupling (in this case, it drops an explicit dependency to an UI component). I will be using it more as I find other use-cases in the code base, didn't look too much.

This PR also explicitly set components names. This might not seem like much now but it should be a first step toward allowing feature discovery later down the road.

As an aside : I tried to implement a ServiceLoader but was not happy with it as it did not make use of spring features and would just have made the application more bloated. Will give it another go when i find a more fitting design. For now, it feels like autowired components should be configured as attributes instead of being provided in constructor to limit the bloat seen in #272 .