### PR TITLE
Fix/no while true

### DIFF
--- a/src/main/java/com/kodedu/controller/ApplicationController.java
+++ b/src/main/java/com/kodedu/controller/ApplicationController.java
@@ -612,6 +612,7 @@ public class ApplicationController extends TextWebSocketHandler implements Initi
         Arrays.asList(htmlPane, slidePane, liveReloadPane).forEach(viewPanel -> VBox.getVgrow(viewPanel));
 
         threadService.runTaskLater(() -> {
+            // Main loop for the app
             while (true) {
                 try {
                     renderLoop();

--- a/src/main/java/com/kodedu/service/impl/DirectoryServiceImpl.java
+++ b/src/main/java/com/kodedu/service/impl/DirectoryServiceImpl.java
@@ -362,19 +362,13 @@ public class DirectoryServiceImpl implements DirectoryService {
         if (optional.isPresent()) {
             Path currentParent = optional.get();
 
-            while (true) {
-
-                if (Objects.nonNull(currentParent)) {
-                    Path candidate = currentParent.resolve(uri);
-                    if (Files.exists(candidate)) {
-                        return candidate;
-                    } else {
-                        currentParent = currentParent.getParent();
-                    }
-                } else {
-                    break;
+            while (Objects.nonNull(currentParent)) {
+                Path candidate = currentParent.resolve(uri);
+                if (Files.exists(candidate)) {
+                    return candidate;
                 }
 
+                currentParent = currentParent.getParent();
             }
 
         }

--- a/src/main/java/com/kodedu/service/ui/impl/FileBrowseServiceImpl.java
+++ b/src/main/java/com/kodedu/service/ui/impl/FileBrowseServiceImpl.java
@@ -285,33 +285,26 @@ public class FileBrowseServiceImpl implements FileBrowseService {
 
             ListIterator<TreeItem<Item>> listIterator = foundItems.listIterator();
 
-            while (true) {
-
-                if (Objects.isNull(searchFoundItem)) {
-                    if (listIterator.hasNext()) {
-                        searchFoundItem = listIterator.next();
-                    }
-                    break;
-                }
-
+            if (Objects.isNull(searchFoundItem)) {
                 if (listIterator.hasNext()) {
-                    TreeItem<Item> next = listIterator.next();
-                    if (next.getValue().equals(searchFoundItem.getValue())) {
-                        if (listIterator.hasNext()) {
-                            TreeItem<Item> nexted = listIterator.next();
+                    searchFoundItem = listIterator.next();
+                }
+            }
+            while (listIterator.hasNext()) {
+                TreeItem<Item> next = listIterator.next();
+                if (next.getValue().equals(searchFoundItem.getValue())) {
+                    if (listIterator.hasNext()) {
+                        TreeItem<Item> nexted = listIterator.next();
 
-                            if (next == nexted) {
-                                if (listIterator.hasNext()) {
-                                    nexted = listIterator.next();
-                                }
+                        if (next == nexted) {
+                            if (listIterator.hasNext()) {
+                                nexted = listIterator.next();
                             }
-
-                            searchFoundItem = nexted;
-                            break;
                         }
+
+                        searchFoundItem = nexted;
+                        break;
                     }
-                } else {
-                    break;
                 }
 
             }
@@ -332,34 +325,23 @@ public class FileBrowseServiceImpl implements FileBrowseService {
 
             ListIterator<TreeItem<Item>> listIterator = foundItems.listIterator();
 
-            while (true) {
-
-                if (Objects.isNull(searchFoundItem)) {
-                    if (listIterator.hasPrevious()) {
-                        searchFoundItem = listIterator.previous();
-                    }
-
-                    break;
-                }
-
+            if (Objects.isNull(searchFoundItem)) {
                 if (listIterator.hasNext()) {
-                    TreeItem<Item> next = listIterator.next();
-                    if (next.getValue().equals(searchFoundItem.getValue())) {
-                        if (listIterator.hasPrevious()) {
-                            TreeItem<Item> previous = listIterator.previous();
-                            if (next == previous) {
-                                if (listIterator.hasPrevious()) {
-                                    previous = listIterator.previous();
-                                }
-                            }
-                            searchFoundItem = previous;
-                            break;
-                        }
-                    }
-                } else {
-                    break;
+                    searchFoundItem = listIterator.next();
                 }
+            } else {
 
+                while (listIterator.hasNext()) {
+                    TreeItem<Item> next = listIterator.next();
+                    if (next.getValue().equals(searchFoundItem.getValue()) && listIterator.hasPrevious()) {
+                        TreeItem<Item> previous = listIterator.previous();
+                        if (next == previous && listIterator.hasPrevious()) {
+                            previous = listIterator.previous();
+                        }
+                        searchFoundItem = previous;
+                        break;
+                    }
+                }
             }
 
             focusFoundItem(searchFoundItem);
@@ -438,7 +420,6 @@ public class FileBrowseServiceImpl implements FileBrowseService {
             }
 
             ListIterator<TreeItem<Item>> listIterator = foundItems.listIterator();
-
 
             if (Objects.isNull(searchFoundItem)) {
                 if (listIterator.hasNext()) {


### PR DESCRIPTION
Fix #524 and added comments on the loops where a `while(true)` seemed legitimate to justify them.

Note that:

* The file watcher now resets right after polling to limit the risks of missing a file update and guaranteeing that it does reset even if no event was polled for some reason
* In `FileBrowseServiceImpl.searchDownAndSelect`, I replaced the use of previous by next in `if (Objects.isNull(searchFoundItem))` as I could not make sense of the code the way it was.

Other than that, old and new code should be strictly equivalent