### PR TITLE
Fix docinfo path error when generating html file

### DIFF
--- a/src/main/java/com/kodedu/controller/WebWorkerResource.java
+++ b/src/main/java/com/kodedu/controller/WebWorkerResource.java
@@ -69,6 +69,10 @@ public class WebWorkerResource {
         if (optional.isPresent()) {
             finalURI = payload.param("path");
         }
+        
+        if (finalURI.contains("docinfo") && finalURI.contains(".html") && finalURI.startsWith("./")) {
+            finalURI = finalURI.replace("./", "");
+        }
 
         if (finalURI.matches(".*\\.(asc|asciidoc|ad|adoc|md|markdown)$")) {
 


### PR DESCRIPTION
It happened in Windows 10 environment.

	ERROR => UT005023: Exception handling request to /afx/worker/js/resource.afx
	org.springframework.web.util.NestedServletException: Request processing failed; nested exception is java.lang.IllegalArgumentException: Illegal character in path at index 4: ./C:\asciidoc\docs/docinfo.html
		at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1014)
		at org.springframework.web.servlet.FrameworkServlet.doPost(FrameworkServlet.java:909)
		at javax.servlet.http.HttpServlet.service(HttpServlet.java:517)
		at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:883)
		at javax.servlet.http.HttpServlet.service(HttpServlet.java:584)
		at io.undertow.servlet.handlers.ServletHandler.handleRequest(ServletHandler.java:74)
		at io.undertow.servlet.handlers.FilterHandler$FilterChainImpl.doFilter(FilterHandler.java:129)
		at org.springframework.web.filter.RequestContextFilter.doFilterInternal(RequestContextFilter.java:100)
		at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119)
		at io.undertow.servlet.core.ManagedFilter.doFilter(ManagedFilter.java:61)
		at io.undertow.servlet.handlers.FilterHandler$FilterChainImpl.doFilter(FilterHandler.java:131)
		at org.springframework.web.filter.FormContentFilter.doFilterInternal(FormContentFilter.java:93)
		at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119)
		at io.undertow.servlet.core.ManagedFilter.doFilter(ManagedFilter.java:61)
		at io.undertow.servlet.handlers.FilterHandler$FilterChainImpl.doFilter(FilterHandler.java:131)
		at org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:201)
		at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119)
		at io.undertow.servlet.core.ManagedFilter.doFilter(ManagedFilter.java:61)
		at io.undertow.servlet.handlers.FilterHandler$FilterChainImpl.doFilter(FilterHandler.java:131)
		at io.undertow.servlet.handlers.FilterHandler.handleRequest(FilterHandler.java:84)
		at io.undertow.servlet.handlers.security.ServletSecurityRoleHandler.handleRequest(ServletSecurityRoleHandler.java:62)
		at io.undertow.servlet.handlers.ServletChain$1.handleRequest(ServletChain.java:68)
		at io.undertow.servlet.handlers.ServletDispatchingHandler.handleRequest(ServletDispatchingHandler.java:36)
		at io.undertow.servlet.handlers.RedirectDirHandler.handleRequest(RedirectDirHandler.java:68)
		at io.undertow.servlet.handlers.security.SSLInformationAssociationHandler.handleRequest(SSLInformationAssociationHandler.java:117)
		at io.undertow.servlet.handlers.security.ServletAuthenticationCallHandler.handleRequest(ServletAuthenticationCallHandler.java:57)
		at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
		at io.undertow.security.handlers.AbstractConfidentialityHandler.handleRequest(AbstractConfidentialityHandler.java:46)
		at io.undertow.servlet.handlers.security.ServletConfidentialityConstraintHandler.handleRequest(ServletConfidentialityConstraintHandler.java:64)
		at io.undertow.security.handlers.AuthenticationMechanismsHandler.handleRequest(AuthenticationMechanismsHandler.java:60)
		at io.undertow.servlet.handlers.security.CachedAuthenticatedSessionHandler.handleRequest(CachedAuthenticatedSessionHandler.java:77)
		at io.undertow.security.handlers.AbstractSecurityContextAssociationHandler.handleRequest(AbstractSecurityContextAssociationHandler.java:43)
		at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
		at io.undertow.servlet.handlers.SendErrorPageHandler.handleRequest(SendErrorPageHandler.java:52)
		at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
		at io.undertow.servlet.handlers.ServletInitialHandler.handleFirstRequest(ServletInitialHandler.java:269)
		at io.undertow.servlet.handlers.ServletInitialHandler.access$100(ServletInitialHandler.java:78)
		at io.undertow.servlet.handlers.ServletInitialHandler$2.call(ServletInitialHandler.java:133)
		at io.undertow.servlet.handlers.ServletInitialHandler$2.call(ServletInitialHandler.java:130)
		at io.undertow.servlet.core.ServletRequestContextThreadSetupAction$1.call(ServletRequestContextThreadSetupAction.java:48)
		at io.undertow.servlet.core.ContextClassLoaderSetupAction$1.call(ContextClassLoaderSetupAction.java:43)
		at io.undertow.servlet.handlers.ServletInitialHandler.dispatchRequest(ServletInitialHandler.java:249)
		at io.undertow.servlet.handlers.ServletInitialHandler.access$000(ServletInitialHandler.java:78)
		at io.undertow.servlet.handlers.ServletInitialHandler$1.handleRequest(ServletInitialHandler.java:99)
		at io.undertow.server.Connectors.executeRootHandler(Connectors.java:387)
		at io.undertow.server.HttpServerExchange$1.run(HttpServerExchange.java:841)
		at org.jboss.threads.ContextClassLoaderSavingRunnable.run(ContextClassLoaderSavingRunnable.java:35)
		at org.jboss.threads.EnhancedQueueExecutor.safeRun(EnhancedQueueExecutor.java:2019)
		at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.doRunTask(EnhancedQueueExecutor.java:1558)
		at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1449)
		at java.base/java.lang.Thread.run(Thread.java:853)
	Caused by: java.lang.IllegalArgumentException: Illegal character in path at index 4: ./C:\asciidoc\docs/docinfo.html
		at java.base/java.net.URI.create(URI.java:906)
		at com.kodedu.helper.IOHelper.getPath(IOHelper.java:596)
		at com.kodedu.controller.WebWorkerResource.onrequest(WebWorkerResource.java:102)
		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:78)
		at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
		at java.base/java.lang.reflect.Method.invoke(Method.java:567)
		at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:197)
		at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:141)
		at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:106)
		at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:894)
		at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:808)
		at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:87)
		at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1060)
		at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:962)
		at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1006)
		... 50 common frames omitted
	Caused by: java.net.URISyntaxException: Illegal character in path at index 4: ./C:\asciidoc\docs/docinfo.html
		at java.base/java.net.URI$Parser.fail(URI.java:2966)
		at java.base/java.net.URI$Parser.checkChars(URI.java:3137)
		at java.base/java.net.URI$Parser.parseHierarchical(URI.java:3219)
		at java.base/java.net.URI$Parser.parse(URI.java:3178)
		at java.base/java.net.URI.<init>(URI.java:623)
		at java.base/java.net.URI.create(URI.java:904)
		... 65 common frames omitted