### PR TITLE
WindowsPath can not handle colons (:) in template download

### DIFF
--- a/src/main/java/com/kodedu/service/TemplateService.java
+++ b/src/main/java/com/kodedu/service/TemplateService.java
@@ -67,7 +67,7 @@ public class TemplateService {
 
 		}
 
-		Path filePath = _getTargetFilePath(targetDir, locationLowCase, location);
+		Path filePath = getTargetFilePath(targetDir, locationLowCase, location);
 
 		if(isGitRepository){
 			if(Files.exists(filePath)){
@@ -106,7 +106,7 @@ public class TemplateService {
 		logger.debug("Template provided: {}", location);
 	}
 
-	private Path _getTargetFilePath(Path targetDir, String location, final String locationLowCase) {
+	private Path getTargetFilePath(Path targetDir, String location, final String locationLowCase) {
 		if (locationLowCase.startsWith("http:") || locationLowCase.startsWith("https:")) {
 			// remove only first colon, as we are not interested in it
 			// colons are not allowed in WindowsPath, on PosixPath they are allowed


### PR DESCRIPTION
Hello,

the current implementation of the template download does not work under Windows.
The problem is the first colon in a URL, when the filename should be retrieved via the Path API.

```
java.nio.file.InvalidPathException: Illegal char <:> at index 5: https://github.com/asciidocfx/Asciidoc-Book-Demo
	at java.base/sun.nio.fs.WindowsPathParser.normalize(WindowsPathParser.java:182)
	at java.base/sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:153)
	at java.base/sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:77)
	at java.base/sun.nio.fs.WindowsPath.parse(WindowsPath.java:92)
	at java.base/sun.nio.fs.WindowsFileSystem.getPath(WindowsFileSystem.java:232)
...
```

As a simple workaround, the first colon is removed if the location start with `http:` or `https:`.
I am not sure if this is the best way, but handling this correctly, not knowing if the String is a WindowsPath, PosixPath or URL is quite hard.



