### PR TITLE
Add PRQL to ace_doctypes.json

### DIFF
--- a/conf/ace_doctypes.json
+++ b/conf/ace_doctypes.json
@@ -528,6 +528,12 @@
     "extensions": "py"
   },
   {
+    "name": "prql",
+    "caption": "PRQL",
+    "mode": "ace/mode/prql",
+    "extensions": "prql"
+  },
+  {
     "name": "r",
     "caption": "R",
     "mode": "ace/mode/r",


### PR DESCRIPTION
PRQL is a modern language for transforming data — a simple, powerful, pipelined SQL replacement.

https://prql-lang.org/
https://github.com/PRQL/prql