### PR TITLE
Fix misunderstanding logging statement in BinaryCacheServiceImpl.java

### DIFF
--- a/src/main/java/com/kodedu/service/cache/impl/BinaryCacheServiceImpl.java
+++ b/src/main/java/com/kodedu/service/cache/impl/BinaryCacheServiceImpl.java
@@ -91,7 +91,7 @@ public class BinaryCacheServiceImpl implements BinaryCacheService {
     private void shrinkCache() {
         threadService.runTaskLater(() -> {
             Collection<CacheData> values = cache.values();
-            logger.debug("Shrink cache: {}", values.size());
+            logger.debug("Shrinking cache, total entries: {}", values.size());
             values
                     .stream()
                     .filter(e -> e.inMemory())
@@ -101,7 +101,7 @@ public class BinaryCacheServiceImpl implements BinaryCacheService {
                         return l2.compareTo(l1);
                     }).limit(5)
                     .forEach(cacheData -> {
-                        logger.debug("Shrinked: {}", cacheData.key());
+                        logger.debug("Shrunk cache entry: {}", cacheData.key());
                         byte[] bytes = cacheData.readBytes();
                         saveInDisk(cacheData.key(), bytes);
                         totalSize.addAndGet(-bytes.length);


### PR DESCRIPTION
### Pull Request Title:
Improve Logging Statements and Correct Spelling in `shrinkCache` Method

### Description:
This pull request improves the logging statements and corrects a spelling error in the `shrinkCache` method. The changes enhance the clarity and accuracy of the log messages when shrinking the cache.

**Original Code:**
```java
private void shrinkCache() {
    threadService.runTaskLater(() -> {
        Collection<CacheData> values = cache.values();
        logger.debug("Shrink cache: {}", values.size());
        values.stream().filter(e -> e.inMemory()).sorted((o1, o2) -> {
            Long l1 = o1.lastModified();
            Long l2 = o2.lastModified();
            return l2.compareTo(l1);
        }).limit(5).forEach(cacheData -> {
            logger.debug("Shrinked: {}", cacheData.key());
            byte[] bytes = cacheData.readBytes();
            saveInDisk(cacheData.key(), bytes);
            totalSize.addAndGet(-bytes.length);
        });
    });
}
```

### Changes:
1. **Logging Detail Enhancement**:
    - Added more context to the initial shrinking log statement to indicate the total number of cache entries.
    - Original: 
      ```java
      logger.debug("Shrink cache: {}", values.size());
      ```
    - Improved: 
      ```java
      logger.debug("Shrinking cache, total entries: {}", values.size());
      ```
    - **Reason**: Provides more context and clarity about the action being performed.

2. **Spelling Correction**:
    - Original: 
      ```java
      logger.debug("Shrinked: {}", cacheData.key());
      ```
    - Improved: 
      ```java
      logger.debug("Shrunk cache entry: {}", cacheData.key());
      ```
    - **Reason**: Corrects the grammatical error from "Shrinked" to "Shrunk".

### Code Changes:
```java
private void shrinkCache() {
    threadService.runTaskLater(() -> {
        Collection<CacheData> values = cache.values();
        logger.debug("Shrinking cache, total entries: {}", values.size());
        values.stream().filter(CacheData::inMemory).sorted((o1, o2) -> {
            Long l1 = o1.lastModified();
            Long l2 = o2.lastModified();
            return l2.compareTo(l1);
        }).limit(5).forEach(cacheData -> {
            logger.debug("Shrunk cache entry: {}", cacheData.key());
            byte[] bytes = cacheData.readBytes();
            saveInDisk(cacheData.key(), bytes);
            totalSize.addAndGet(-bytes.length);
        });
    });
}